### PR TITLE
Sending empty menu in semester-brakes bugfix.

### DIFF
--- a/mensabot.py
+++ b/mensabot.py
@@ -194,20 +194,21 @@ class MensaBot(telepot.Bot):
 
     def send_menu_to_clients(self):
         day = datetime.now(TZ).date()
-
+        day = datetime.strptime("28.12.2018", "%d.%m.%Y").date()
+        
         if day.weekday() >= 5:
             return
 
         try:
             menu = get_menu(day)
+            #if parsed menu is empty, we can return and not send empty messages
+            if len(menu) == 0:
+                log.error('Empty menu {}'.format(menu))
+                return
             text = format_menu(menu, date=day)
         except Exception:
             log.exception('Error getting menu')
             text = 'Kein Menü gefunden für {}'.format(day)
-
-        if not text:
-            text = 'Leeres Menü'
-            log.error('Empty menu {}'.format(menu))
 
         for client in Client.select():
             log.info('Sending menu to {}'.format(client.chat_id))

--- a/mensabot.py
+++ b/mensabot.py
@@ -194,7 +194,6 @@ class MensaBot(telepot.Bot):
 
     def send_menu_to_clients(self):
         day = datetime.now(TZ).date()
-        day = datetime.strptime("28.12.2018", "%d.%m.%Y").date()
         
         if day.weekday() >= 5:
             return


### PR DESCRIPTION
The bot was sending messages without a menu (e.g. "Hauptmensa (26.12.2018)") while the mensa is closed. And I thought I can fix this real quick. Maybe you could restart the program on your raspberry. :-)